### PR TITLE
Accept optional filename

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,7 @@ md('# markdown')
 ## Command line usage
 ```
 $ cli-md < Readme.md
+$ cli.md Readme.md
 ```
 Which would look something like this:
 ![Photo](example.png)

--- a/cli.js
+++ b/cli.js
@@ -4,6 +4,10 @@ var concat = require('concat-stream')
 
 var md = require('./')
 
-process.stdin.pipe(concat(function (markdown) {
+var input = process.argv.length > 2
+      ? fs.createReadStream(process.argv[2])
+      : process.stdin
+
+input.pipe(concat(function (markdown) {
   process.stdout.write(md(markdown.toString()))
 }))


### PR DESCRIPTION
This patch makes `cli-md` behave more like `cat`, `grep`, `sed`, and other Unix tools.
