### PR TITLE
Remove extra newline at the end

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,5 +5,5 @@ var concat = require('concat-stream')
 var md = require('./')
 
 process.stdin.pipe(concat(function (markdown) {
-  console.log(md(markdown.toString()))
+  process.stdout.write(md(markdown.toString()))
 }))


### PR DESCRIPTION
`console.log` adds extra newline at the end which is not expected (ideally `cli-md` output and `cat` output are the same bar highlighting).

This patch fixes it by using `process.stdout.write` instead.
