### PR TITLE
Force chalk to always use terminal colors

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,6 +2,9 @@
 var fs = require('fs')
 var concat = require('concat-stream')
 
+// Force colors for chalk.
+process.argv.push('--color')
+
 var md = require('./')
 
 process.stdin.pipe(concat(function (markdown) {


### PR DESCRIPTION
chalk's [`supports-color`](https://github.com/chalk/supports-color) module sniffs `process.argv`, `process.env`, `process.stdout.isTTY`, and `process.platform` to determine whether terminal colors should be applied or not.

This makes sense for applications where colors are used to just make output more readable for human consumption. For example, when users pipe the output of `grep` to the pager or to another `grep` they do not expect the first `grep` to add escape codes to the output.

However, `cli-md` does not belong to this class of applications since its very purpose is to add colors to plain markdown input. Like terminal source highlighters, it should always add colors even if stdout is redirected (you can try it with GNU `source-highlight`). Users do not expect source highlighters to turn colors off when redirected because they can just use `cat` instead.

But currently if they pipe `cli-md` to `less`,

```
$ cli-md <Readme.md |less
```

colors are gone, and there is no documented way to reenable them. They must know that `cli-md` uses `chalk` underneath and add `--color` flag:

```
$ cli-md <Readme.md --color |less
```

This patch forces chalk to always use colors by adding `--color` flag automatically. Simply turning on `chalk.enabled` won't work because there is no way to guarantee that `marked-terminal` uses the same version of `chalk` as this module does.
