### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/finnp/cli-md",
   "dependencies": {
-    "cardinal": "^0.4.4",
     "chalk": "^0.5.1",
     "concat-stream": "^1.4.6",
     "marked": "^0.3.2",


### PR DESCRIPTION
`cardinal` is declared as a dependency but never used.
