### PR TITLE
Add support for input file

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,7 +3,15 @@ var fs = require('fs')
 var concat = require('concat-stream')
 
 var md = require('./')
+var filepath = process.argv[2]
+var readStream
 
-process.stdin.pipe(concat(function (markdown) {
+if (filepath) {
+    readStream = fs.createReadStream(filepath)
+} else {
+    readStream = process.stdin
+}
+
+readStream.pipe(concat(function (markdown) {
   process.stdout.write(md(markdown.toString()))
 }))


### PR DESCRIPTION
Currently, we only use standard input for input. We might want to allow passing a path to a markdown file instead, for convenience.

``` bash
$ cli-md path/to/Readme.md
```
